### PR TITLE
Docker Config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY src /usr/src/app/src
 RUN mvn -f /usr/src/app/pom.xml clean package
 
 FROM jetty:9-jre8-alpine
-COPY --from=build /usr/src/app/target/medmorph.war /var/lib/jetty/webapps/medmorph.war
+COPY --from=build /usr/src/app/target/medmorph.war /var/lib/jetty/webapps/root.war
 COPY --from=build /usr/src/app/target /var/lib/jetty/target 
 COPY src /var/lib/jetty/src
 USER root

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# MedMorph Test EHR
+# MedMorph FHIR Server
 
-This project is a test EHR FHIR server for the [MedMorph Public Health Usecase](https://build.fhir.org/ig/HL7/fhir-medmorph/usecases.html). It is based on the [HAPI FHIR JPA Server (Version 4.1.0)](https://github.com/hapifhir/hapi-fhir-jpaserver-starter).
+This project is a FHIR server which is used for multiple actors (EHR and Knowledge Artifact Repository) in the [MedMorph Public Health Usecase](https://build.fhir.org/ig/HL7/fhir-medmorph/usecases.html). It is based on the [HAPI FHIR JPA Server (Version 4.1.0)](https://github.com/hapifhir/hapi-fhir-jpaserver-starter).
 
 Note: Issues related to performance and Subscriptions were observed on HAPI 5.1.0
 
@@ -10,14 +10,14 @@ The easiest way to run this server is to use docker. First, clone this
 repository. Then, from the repository root run:
 
 ```
-docker build -t medmorph_ehr .
+docker build -t medmorph_fhir .
 ```
 
 This will build the docker image for the reference server. Once the image has
 been built, the server can be run with the following command:
 
 ```
-docker run -p 8080:8080 medmorph_ehr
+docker run -p 8080:8080 medmorph_fhir -e AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/ehr/protocol/openid-connect/ SERVER_ADDRESS=http://localhost:8080/fhir/
 ```
 
 Alternatively the image can be built and run using
@@ -28,12 +28,16 @@ docker-compose up
 ```
 
 The server will then be browseable at
-[http://localhost:8080/medmorph](http://localhost:8080/medmorph), and the
+[http://localhost:8080](http://localhost:8080), and the
 server's FHIR endpoint will be available at
-[http://localhost:8080/medmorph/fhir](http://localhost:8080/medmorph/fhir)
+[http://localhost:8080/fhir](http://localhost:8080/fhir)
+
+# Configuration
+
+Since this is a single repository and single docker image for multiple actors, each container should have its own properties. Right now the properties to configurate are `AUTH_SERVER_ADDRESS` and `SERVER_ADDRESS`. These are set through enviornment variables of the same names. Using compose will automatically create all necessary servers.
 
 # Authorization
 
 This server is protected by the SMART Backend Authentication protocol. The admin token is `admin`. The OAuth URLS can be found at the `/metadata` or `/.well-known/smart-configuration` endpoints.
 
-Follow the [Register New Client](https://github.com/mcode/medmorph-ehr/wiki/Register-New-Client) wiki page to register a new client.
+Follow the [Register New Client](https://github.com/mcode/medmorph-fhir-server/wiki/Register-New-Client) wiki page to register a new client.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,16 @@ Note: Issues related to performance and Subscriptions were observed on HAPI 5.1.
 
 # Running Locally
 
-The easiest way to run this server is to use docker. First, clone this
-repository. Then, from the repository root run:
+The easiest way to run this server is to use docker.
+
+```
+./build-docker-image.sh
+docker-compose up
+```
+
+This will create the `medmorph_fhir` image and spin up the `medmoprh_ehr` (on [http://localhost:8080/fhir](http://localhost:8080/fhir)) and `knowledge_artifact` (on [http://localhost:8090/fhir](http://localhost:8090/fhir)) containers.
+
+Alternatively the image can be built and specific instances run. First, clone this repository. Then, from the repository root run:
 
 ```
 docker build -t medmorph_fhir .
@@ -18,13 +26,6 @@ been built, the server can be run with the following command:
 
 ```
 docker run -p 8080:8080 medmorph_fhir -e AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/ehr/protocol/openid-connect/ SERVER_ADDRESS=http://localhost:8080/fhir/
-```
-
-Alternatively the image can be built and run using
-
-```
-./build-docker-image.sh
-docker-compose up
 ```
 
 The server will then be browseable at
@@ -41,3 +42,28 @@ Since this is a single repository and single docker image for multiple actors, e
 This server is protected by the SMART Backend Authentication protocol. The admin token is `admin`. The OAuth URLS can be found at the `/metadata` or `/.well-known/smart-configuration` endpoints.
 
 Follow the [Register New Client](https://github.com/mcode/medmorph-fhir-server/wiki/Register-New-Client) wiki page to register a new client.
+
+# Hosted Server
+
+An instance of the EHR and Knowledge Artifact Repository is running on `pathways.mitre.org`.
+
+| Service                      | Base URL                            |
+| ---------------------------- | ----------------------------------- |
+| EHR                          | http://pathways.mitre.org:8180/fhir |
+| Knowldge Artifact Repository | http://pathways.mitre.org/8190/fhir |
+
+## Steps to Update
+
+The service will not automatically deploy when changes are made. To update the services:
+
+```
+[localhost] $ git push
+[localhost] $ ssh pathways.mitre.org
+[pathways.mitre.org] $ cd /opt/medmorph-fhir-server
+[pathways.mitre.org] $ git pull
+[pathways.mitre.org] $ docker-compose down
+[pathways.mitre.org] $ ./build-docker-image.bat
+[pathways.mitre.org] $ docker-compose up -d
+```
+
+Before running the last command you can optionally modify the urls and ports in the `docker-compose.yml` file.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This will build the docker image for the reference server. Once the image has
 been built, the server can be run with the following command:
 
 ```
-docker run -p 8080:8080 medmorph_fhir -e AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/ehr/protocol/openid-connect/ SERVER_ADDRESS=http://localhost:8080/fhir/
+docker run -p 8080:8080 medmorph_fhir -e AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/ehr/protocol/openid-connect/ -e SERVER_ADDRESS=http://localhost:8080/fhir/
 ```
 
 The server will then be browseable at
@@ -35,7 +35,7 @@ server's FHIR endpoint will be available at
 
 # Configuration
 
-Since this is a single repository and single docker image for multiple actors, each container should have its own properties. Right now the properties to configurate are `AUTH_SERVER_ADDRESS` and `SERVER_ADDRESS`. These are set through enviornment variables of the same names. Using compose will automatically create all necessary servers.
+Since this is a single repository and single docker image for multiple actors, each container should have its own properties. Right now the properties to configurate are `AUTH_SERVER_ADDRESS`, `SERVER_ADDRESS`, and `SERVER_TITLE`. These are set through enviornment variables of the same names. Using compose will automatically create all necessary servers.
 
 # Authorization
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Note: Issues related to performance and Subscriptions were observed on HAPI 5.1.
 The easiest way to run this server is to use docker.
 
 ```
-./build-docker-image.sh
+./build-docker-image.bat
 docker-compose up
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,28 +42,3 @@ Since this is a single repository and single docker image for multiple actors, e
 This server is protected by the SMART Backend Authentication protocol. The admin token is `admin`. The OAuth URLS can be found at the `/metadata` or `/.well-known/smart-configuration` endpoints.
 
 Follow the [Register New Client](https://github.com/mcode/medmorph-fhir-server/wiki/Register-New-Client) wiki page to register a new client.
-
-# Hosted Server
-
-An instance of the EHR and Knowledge Artifact Repository is running on `pathways.mitre.org`.
-
-| Service                      | Base URL                            |
-| ---------------------------- | ----------------------------------- |
-| EHR                          | http://pathways.mitre.org:8180/fhir |
-| Knowldge Artifact Repository | http://pathways.mitre.org:8190/fhir |
-
-## Steps to Update
-
-The service will not automatically deploy when changes are made. To update the services:
-
-```
-[localhost] $ git push
-[localhost] $ ssh pathways.mitre.org
-[pathways.mitre.org] $ cd /opt/medmorph-fhir-server
-[pathways.mitre.org] $ git pull
-[pathways.mitre.org] $ docker-compose down
-[pathways.mitre.org] $ ./build-docker-image.bat
-[pathways.mitre.org] $ docker-compose up -d
-```
-
-Before running the last command you can optionally modify the urls and ports in the `docker-compose.yml` file.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ An instance of the EHR and Knowledge Artifact Repository is running on `pathways
 | Service                      | Base URL                            |
 | ---------------------------- | ----------------------------------- |
 | EHR                          | http://pathways.mitre.org:8180/fhir |
-| Knowldge Artifact Repository | http://pathways.mitre.org/8190/fhir |
+| Knowldge Artifact Repository | http://pathways.mitre.org:8190/fhir |
 
 ## Steps to Update
 

--- a/build-docker-image.bat
+++ b/build-docker-image.bat
@@ -1,1 +1,1 @@
-docker build -t medmorph_ehr .
+docker build -t medmorph_fhir .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - SERVER_ADDRESS=http://localhost:8080/medmorph/fhir/
-      - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/medmorph/protocol/openid-connect/
+      - SERVER_ADDRESS=http://localhost:8080/fhir/
+      - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/ehr/protocol/openid-connect/
   knowledge_artifact:
     image: medmorph_fhir
     container_name: knowledge_artifact
@@ -17,5 +17,5 @@ services:
     ports:
       - "8090:8080"
     environment:
-      - SERVER_ADDRESS=http://localhost:8090/medmorph/fhir/
-      - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/medmorph/protocol/openid-connect/
+      - SERVER_ADDRESS=http://localhost:8090/fhir/
+      - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/knowledgeartifact/protocol/openid-connect/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     environment:
       - SERVER_ADDRESS=http://localhost:8080/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/ehr/protocol/openid-connect/
+      - SERVER_TITLE='MedMorph EHR'
   knowledge_artifact:
     image: medmorph_fhir
     container_name: knowledge_artifact
@@ -19,3 +20,4 @@ services:
     environment:
       - SERVER_ADDRESS=http://localhost:8090/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/knowledgeartifact/protocol/openid-connect/
+      - SERVER_TITLE='Knowledge Artifact Repository'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,20 @@ version: "3"
 
 services:
   medmorph_ehr:
-    image: medmorph_ehr
+    image: medmorph_fhir
     container_name: medmorph_ehr
     restart: on-failure
     ports:
       - "8080:8080"
+    environment:
+      - SERVER_ADDRESS=http://localhost:8080/medmorph/fhir/
+      - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/medmorph/protocol/openid-connect/
+  knowledge_artifact:
+    image: medmorph_fhir
+    container_name: knowledge_artifact
+    restart: on-failure
+    ports:
+      - "8090:8080"
+    environment:
+      - SERVER_ADDRESS=http://localhost:8090/medmorph/fhir/
+      - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/medmorph/protocol/openid-connect/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       - SERVER_ADDRESS=http://localhost:8080/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/ehr/protocol/openid-connect/
-      - SERVER_TITLE='MedMorph EHR'
+      - SERVER_TITLE=MedMorph EHR
   knowledge_artifact:
     image: medmorph_fhir
     container_name: knowledge_artifact
@@ -20,4 +20,4 @@ services:
     environment:
       - SERVER_ADDRESS=http://localhost:8090/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/knowledgeartifact/protocol/openid-connect/
-      - SERVER_TITLE='Knowledge Artifact Repository'
+      - SERVER_TITLE=Knowledge Artifact Repository

--- a/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
@@ -23,7 +23,7 @@ import static org.apache.commons.lang3.StringUtils.*;
 
 public class HapiProperties {
   static final String ENABLE_INDEX_MISSING_FIELDS = "enable_index_missing_fields";
-    static final String AUTH_SERVER_ADDRESS = "auth_server_address";
+    static final String AUTH_SERVER_ADDRESS = "AUTH_SERVER_ADDRESS";
     static final String AUTO_CREATE_PLACEHOLDER_REFERENCE_TARGETS = "auto_create_placeholder_reference_targets";
     static final String ENFORCE_REFERENTIAL_INTEGRITY_ON_WRITE = "enforce_referential_integrity_on_write";
     static final String ENFORCE_REFERENTIAL_INTEGRITY_ON_DELETE = "enforce_referential_integrity_on_delete";
@@ -50,7 +50,7 @@ public class HapiProperties {
     static final String LOGGER_NAME = "logger.name";
     static final String MAX_FETCH_SIZE = "max_fetch_size";
     static final String MAX_PAGE_SIZE = "max_page_size";
-    static final String SERVER_ADDRESS = "server_address";
+    static final String SERVER_ADDRESS = "SERVER_ADDRESS";
     static final String SERVER_ID = "server.id";
     static final String SERVER_NAME = "server.name";
     static final String SUBSCRIPTION_EMAIL_ENABLED = "subscription.email.enabled";
@@ -251,15 +251,15 @@ public class HapiProperties {
     }
 
     public static String getServerAddress() {
-        return HapiProperties.getProperty(SERVER_ADDRESS);
+        return System.getenv(SERVER_ADDRESS);
     }
 
     public static String getAuthServerTokenAddress() {
-        return HapiProperties.getProperty(AUTH_SERVER_ADDRESS) + "token";
+        return System.getenv(AUTH_SERVER_ADDRESS) + "token";
     }
 
     public static String getAuthServerCertsAddress() {
-        return HapiProperties.getProperty(AUTH_SERVER_ADDRESS) + "certs";
+        return System.getenv(AUTH_SERVER_ADDRESS) + "certs";
     }
 
     public static Integer getDefaultPageSize() {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/Metadata.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/Metadata.java
@@ -21,13 +21,13 @@ public class Metadata extends ServerCapabilityStatementProvider {
     @Override
     public CapabilityStatement getServerConformance(HttpServletRequest request, RequestDetails requestDetails) {
         CapabilityStatement c = super.getServerConformance(request, requestDetails);
-        c.setTitle("MedMorph EHR");
+        c.setTitle(getTitle());
         c.setExperimental(true);
         c.setPublisher("MITRE");
         c.addImplementationGuide("https://build.fhir.org/ig/HL7/fhir-medmorph/index.html");
 
         CapabilityStatementSoftwareComponent software = new CapabilityStatementSoftwareComponent();
-        software.setName("https://github.com/mcode/medmorph-ehr");
+        software.setName("https://github.com/mcode/medmorph-fhir-server");
         c.setSoftware(software);
 
         CapabilityStatementRestSecurityComponent securityComponent = new CapabilityStatementRestSecurityComponent();
@@ -56,6 +56,18 @@ public class Metadata extends ServerCapabilityStatementProvider {
             rest.setSecurity(securityComponent);
 
         return c;
+    }
+
+    private String getTitle() {
+        String title = "MedMorph FHIR Server";
+        try {
+            String envTitle = System.getenv("SERVER_TITLE");
+            if (envTitle != null) return envTitle;
+        } catch (NullPointerException | SecurityException e) {
+            e.printStackTrace();
+        }
+
+        return title; 
     }
     
 }


### PR DESCRIPTION
Configurate docker to use environment variables to allow multiple instances of the same software. Update docker compose to start two instances. Renamed "medmorph" realm on Keycloak to"ehr" and added the "knowledgeartifact" realm. 

EHR and KA are running on pathways.mitre.org at:
EHR: http://pathways.mitre.org:8180/fhir
KA: http://pathways.mitre.org:8190/fhir