### PR TITLE
WIP: process messages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,5 +29,5 @@ services:
       - "8081:8080"
     environment:
       - SERVER_ADDRESS=http://localhost:8081/fhir/
-      - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/knowledgeartifact/protocol/openid-connect/
+      - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/pha/protocol/openid-connect/
       - SERVER_TITLE=Public Health Authority

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,13 @@ services:
       - SERVER_ADDRESS=http://localhost:8090/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/knowledgeartifact/protocol/openid-connect/
       - SERVER_TITLE=Knowledge Artifact Repository
+  public_health_authority:
+    image: medmorph_fhir
+    container_name: public_health_authority
+    restart: on-failure
+    ports:
+      - "8081:8080"
+    environment:
+      - SERVER_ADDRESS=http://localhost:8081/fhir/
+      - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/knowledgeartifact/protocol/openid-connect/
+      - SERVER_TITLE=Public Health Authority

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -86,6 +86,7 @@ public class JpaRestfulServer extends RestfulServer {
 
     setFhirContext(appCtx.getBean(FhirContext.class));
 
+    registerProvider(new MyPlainProvider());
     registerProviders(resourceProviders.createProviders());
     registerProvider(systemProvider);
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -85,8 +85,8 @@ public class JpaRestfulServer extends RestfulServer {
     }
 
     setFhirContext(appCtx.getBean(FhirContext.class));
+    registerProvider(new MessagePlainProvider(appCtx.getBean(DaoRegistry.class), this.getFhirContext()));
 
-    registerProvider(new MyPlainProvider());
     registerProviders(resourceProviders.createProviders());
     registerProvider(systemProvider);
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/MessagePlainProvider.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/MessagePlainProvider.java
@@ -49,6 +49,7 @@ public class MessagePlainProvider {
           .setSeverity(OperationOutcome.IssueSeverity.ERROR)
           .setDiagnostics("Bundle is not of type 'message'");
       respondWithResource(oo, theServletResponse, parser);
+      return;
     }
 
     if (!bundleR4.hasEntry()) {
@@ -57,6 +58,7 @@ public class MessagePlainProvider {
           .setSeverity(OperationOutcome.IssueSeverity.ERROR)
           .setDiagnostics("Bundle has no entries, a MessageHeader is required");
       respondWithResource(oo, theServletResponse, parser);
+      return;
     }
 
     // check that there is a message header
@@ -67,6 +69,7 @@ public class MessagePlainProvider {
           .setSeverity(OperationOutcome.IssueSeverity.ERROR)
           .setDiagnostics("First resource in message bundle must be of type 'MessageHeader'");
       respondWithResource(oo, theServletResponse, parser);
+      return;
     }
 
     MessageHeader msgHead = (MessageHeader) firstResource;
@@ -78,12 +81,14 @@ public class MessagePlainProvider {
           .setSeverity(OperationOutcome.IssueSeverity.ERROR)
           .setDiagnostics("'MessageHeader' is missing source");
       respondWithResource(oo, theServletResponse, parser);
+      return;
     } else if (!msgHead.getSource().hasEndpoint()){
       OperationOutcome oo = new OperationOutcome();
       oo.addIssue()
           .setSeverity(OperationOutcome.IssueSeverity.ERROR)
           .setDiagnostics("'MessageHeader.source' is missing an endpoint");
       respondWithResource(oo, theServletResponse, parser);
+      return;
     }
 
     // use the DAO to create resources in the fhir server
@@ -115,12 +120,13 @@ public class MessagePlainProvider {
       } catch (IOException e) {
         e.printStackTrace();
       }
-
+      return;
     } else {
       // synchronous
       ResponseType responseType = doEvent(msgHead);
       Bundle bundle = buildResponseMessage(msgHead, responseType);
       respondWithResource(bundle, theServletResponse, parser);
+      return;
     }
   }
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/MyPlainProvider.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/MyPlainProvider.java
@@ -1,0 +1,157 @@
+package ca.uhn.fhir.jpa.starter;
+
+import ca.uhn.fhir.context.FhirContext;
+import ca.uhn.fhir.parser.IParser;
+import ca.uhn.fhir.rest.annotation.Operation;
+import ca.uhn.fhir.rest.annotation.OptionalParam;
+import ca.uhn.fhir.rest.annotation.ResourceParam;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.HttpClients;
+import org.hl7.fhir.instance.model.api.IBaseResource;
+import org.hl7.fhir.r4.model.Bundle;
+import org.hl7.fhir.r4.model.MessageHeader;
+import org.hl7.fhir.r4.model.OperationOutcome;
+import org.hl7.fhir.r4.model.Reference;
+import org.hl7.fhir.r4.model.Resource;
+import org.hl7.fhir.r4.model.ResourceType;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+
+public class MyPlainProvider {
+  @Operation(name="$process-message")
+  public IBaseResource processMessage(
+      @OptionalParam(name="async") String async,
+      @OptionalParam(name="response-url") String responseUrl,
+      @ResourceParam Bundle bundleR4
+  ) {
+    // validate the bundle
+    if (bundleR4.getType() != Bundle.BundleType.MESSAGE) {
+      OperationOutcome oo = new OperationOutcome();
+      oo.addIssue()
+          .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+          .setDiagnostics("Bundle is not of type 'message'");
+      return oo;
+    }
+
+    if (!bundleR4.hasEntry()) {
+      OperationOutcome oo = new OperationOutcome();
+      oo.addIssue()
+          .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+          .setDiagnostics("Bundle has no entries, a MessageHeader is required");
+      return oo;
+    }
+
+    // check that there is a message header
+    Resource firstResource = bundleR4.getEntryFirstRep().getResource();
+    if ( firstResource.getResourceType() != ResourceType.MessageHeader) {
+      OperationOutcome oo = new OperationOutcome();
+      oo.addIssue()
+          .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+          .setDiagnostics("First resource in message bundle must be of type 'MessageHeader'");
+      return oo;
+    }
+
+    MessageHeader msgHead = (MessageHeader) firstResource;
+
+    // check messageHeader is well formed
+    if (!msgHead.hasSource()) {
+      OperationOutcome oo = new OperationOutcome();
+      oo.addIssue()
+          .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+          .setDiagnostics("'MessageHeader' is missing source");
+      return oo;
+    } else if (!msgHead.getSource().hasEndpoint()){
+      OperationOutcome oo = new OperationOutcome();
+      oo.addIssue()
+          .setSeverity(OperationOutcome.IssueSeverity.ERROR)
+          .setDiagnostics("'MessageHeader.source' is missing an endpoint");
+      return oo;
+    }
+
+
+    System.out.println(async);
+    if (async.equals("true")) {
+      // asynchronous
+      String asyncResponseUrl;
+      if (responseUrl != null) {
+        asyncResponseUrl = responseUrl;
+      } else {
+        asyncResponseUrl = msgHead.getSource().getEndpoint();
+      }
+      // do any async operations in the new thread
+      Thread newThread = new Thread(() -> {
+        MessageHeader.ResponseType responseType = doEvent(msgHead);
+        Bundle bundle = buildResponseMessage(msgHead, responseType);
+        FhirContext ctx = FhirContext.forR4();
+        IParser parser = ctx.newJsonParser();
+        String bundleString = parser.encodeResourceToString(bundle);
+        makePost(asyncResponseUrl, bundleString);
+      });
+      newThread.start();
+      OperationOutcome oo = new OperationOutcome();
+      oo.addIssue()
+          .setSeverity(OperationOutcome.IssueSeverity.INFORMATION)
+          .setDiagnostics("Asynchronous message successfully received");
+      return oo;
+
+    } else {
+      // synchronous
+      MessageHeader.ResponseType responseType = doEvent(msgHead);
+      return buildResponseMessage(msgHead, responseType);
+    }
+  }
+
+  private void makePost(String asyncResponseUrl, String content) {
+    HttpClient httpClient = HttpClients.createDefault();
+    HttpPost httpPost = new HttpPost(asyncResponseUrl);
+    try {
+      StringEntity entity = new StringEntity(content);
+      httpPost.setEntity(entity);
+      httpPost.setHeader("Content-type", "application/json");
+      httpClient.execute(httpPost);
+    } catch (UnsupportedEncodingException e) {
+      e.printStackTrace();
+    } catch (ClientProtocolException e) {
+      e.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
+  private MessageHeader.ResponseType doEvent(MessageHeader msgHead) {
+    // TODO: this function should synchronously
+    // complete whatever event the message has asked for
+    // The "focus" list is a list of reference resources
+    List<Reference> references = msgHead.getFocus();
+    if (msgHead.hasEventCoding()) {
+      String code = msgHead.getEventCoding().getCode();
+      String system = msgHead.getEventCoding().getSystem();
+    } else if (msgHead.hasEventUriType()) {
+      String uri = msgHead.getEventUriType().fhirType();
+    }
+    return MessageHeader.ResponseType.OK;
+  }
+
+
+
+  private Bundle buildResponseMessage(MessageHeader requestHeader, MessageHeader.ResponseType responseType) {
+    String serverAddress = HapiProperties.getServerAddress();
+    Bundle response = new Bundle();
+    response.setType(Bundle.BundleType.MESSAGE);
+    MessageHeader header = new MessageHeader();
+    header.addDestination().setEndpoint(requestHeader.getSource().getEndpoint());
+    header.setSource(new MessageHeader.MessageSourceComponent()
+        .setEndpoint(serverAddress + "$process-message"));
+    header.setResponse(new MessageHeader.MessageHeaderResponseComponent()
+        .setCode(responseType));
+    response.addEntry().setResource(header);
+    return response;
+  }
+
+
+}


### PR DESCRIPTION
Adds the `$process-message` endpoint to the fhir server, which accepts messages and processes them.  Right now it simply returns a premade message bundle and doesn't do anything with the incoming request besides validate it and parse it out to send to stand-in functions that will eventually use the code to do some process.

You can test the endpoint by sending it a message bundle, and you can test the asynchronous capability by setting `async=true` and `response-url=<backend url>` in the parameters.  This will send a message bundle to the backend server, and an `OperationOutcome` as a response to the actual request.  

Here is the bundle that I used to test:
```
{
    "resourceType": "Bundle",
    "id": "1234",
    "type": "message",
    "entry": [
      {
      "fullUrl": "example",
      "resource": {
        "resourceType": "MessageHeader",
        "id": "267b18ce-3d37-4581-9baa-6fada338038b",
        "eventCoding": {
          "system": "http://example.org/fhir/message-events",
          "code": "example-code"
        },
        "source": {
          "endpoint": "http://<localhost or ip address>/fhir/$process-message"
        }
      }
    }
  ]
}
```