### PR TITLE
Replace BackendAuthorizationInterceptor with Generic JWT Verifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This will build the docker image for the reference server. Once the image has
 been built, the server can be run with the following command:
 
 ```
-docker run -p 8080:8080 medmorph_fhir -e AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/ehr/protocol/openid-connect/ -e SERVER_ADDRESS=http://localhost:8080/fhir/
+docker run -p 8080:8080 -e AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/ehr/protocol/openid-connect/ -e SERVER_ADDRESS=http://localhost:8080/fhir/ -e SERVER_TITLE=EHR medmorph_fhir
 ```
 
 The server will then be browseable at

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,11 @@
 		    <version>20190722</version>
 		</dependency>
         <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>3.10.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.okhttp</groupId>
             <artifactId>okhttp</artifactId>
             <version>2.5.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.keycloak</groupId>
-            <artifactId>keycloak-core</artifactId>
-            <version>12.0.1</version>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-crypto</artifactId>
             <version>3.1.0.RELEASE</version>

--- a/src/main/java/ca/uhn/fhir/jpa/starter/BackendAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/BackendAuthorizationInterceptor.java
@@ -63,7 +63,7 @@ public class BackendAuthorizationInterceptor extends AuthorizationInterceptor {
                     } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
                         e.printStackTrace();
                         throw new AuthenticationException("Internal error processing public key", e);
-					}
+                    }
                 }
 
             }

--- a/src/main/java/ca/uhn/fhir/jpa/starter/BackendAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/BackendAuthorizationInterceptor.java
@@ -63,6 +63,9 @@ public class BackendAuthorizationInterceptor extends AuthorizationInterceptor {
                     } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
                         e.printStackTrace();
                         throw new AuthenticationException("Internal error processing public key", e);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        throw new AuthenticationException("Unable to authorize token", e);
                     }
                 }
 

--- a/src/main/java/ca/uhn/fhir/jpa/starter/BackendAuthorizationInterceptor.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/BackendAuthorizationInterceptor.java
@@ -124,7 +124,7 @@ public class BackendAuthorizationInterceptor extends AuthorizationInterceptor {
         return true;
     }
 
-    private Algorithm getAlgorithm(String token, Object publicKey) {
+    private Algorithm getAlgorithm(String token, Object publicKey) throws NoSuchAlgorithmException {
         // Decode the header of the token
         String header = token.split("\\.")[0];
         byte[] decodedBytes = Base64.getDecoder().decode(header);
@@ -156,7 +156,7 @@ public class BackendAuthorizationInterceptor extends AuthorizationInterceptor {
             case "PS256":
             case "PS384":
             default:
-                return null;
+                throw new NoSuchAlgorithmException("Algorithm is not supported by this library.");
         }
     }
 


### PR DESCRIPTION
Remove the Keycloak verifier to use an Auth0 JWT Verifier. Note this will not work for _all_ tokens, it must still be a JWT access token but can be signed with a variety of algorithms and come from a server other than Keycloak. The ticket mentions pushing these changes upstream to HAPI but I'm not sure if they would want this since its only for JWT access tokens.