### PR TITLE
Add ADMIN_TOKEN env

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ server's FHIR endpoint will be available at
 
 # Configuration
 
-Since this is a single repository and single docker image for multiple actors, each container should have its own properties. Right now the properties to configurate are `AUTH_SERVER_ADDRESS`, `SERVER_ADDRESS`, and `SERVER_TITLE`. These are set through enviornment variables of the same names. Using compose will automatically create all necessary servers.
+Since this is a single repository and single docker image for multiple actors, each container should have its own properties. Right now the properties to configurate are `AUTH_SERVER_ADDRESS`, `SERVER_ADDRESS`, `SERVER_TITLE`, and `ADMIN_TOKEN`. These are set through enviornment variables of the same names. Using compose will automatically create all necessary servers.
 
 # Authorization
 
@@ -47,8 +47,8 @@ This server is protected by the SMART Backend Authentication protocol. The admin
 
 Follow the [Register New Client](https://github.com/mcode/medmorph-fhir-server/wiki/Register-New-Client) wiki page to register a new client.
 
-
 # License
+
 Copyright 2021 The MITRE Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - SERVER_ADDRESS=https://pathways.mitre.org:8440/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/ehr/protocol/openid-connect/
       - SERVER_TITLE=MedMorph EHR
+      - ADMIN_TOKEN=admin
   knowledge_artifact:
     image: medmorph_fhir
     container_name: knowledge_artifact
@@ -21,6 +22,7 @@ services:
       - SERVER_ADDRESS=https://pathways.mitre.org:8550/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/knowledgeartifact/protocol/openid-connect/
       - SERVER_TITLE=Knowledge Artifact Repository
+      - ADMIN_TOKEN=admin
   public_health_authority:
     image: medmorph_fhir
     container_name: public_health_authority
@@ -31,3 +33,4 @@ services:
       - SERVER_ADDRESS=https://pathways.mitre.org:8660/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/pha/protocol/openid-connect/
       - SERVER_TITLE=Public Health Authority
+      - ADMIN_TOKEN=admin


### PR DESCRIPTION
Include ADMIN_TOKEN in the docker-compose file. Related to https://github.com/mcode/smart-backend-auth/pull/1