### PR TITLE
R5 Subscription Backport Library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,11 @@
         	<artifactId>smart-backend-auth</artifactId>
         	<version>0.0.3</version>
         </dependency>
+        <dependency>
+        	<groupId>org.mitre.hapifhir</groupId>
+        	<artifactId>r5-subscription-backport</artifactId>
+        	<version>0.0.1</version>
+        </dependency>
     </dependencies>
 
     <packaging>war</packaging>

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -24,6 +24,7 @@ import ca.uhn.fhir.jpa.subscription.dbmatcher.DaoSubscriptionMatcher;
 import ca.uhn.fhir.jpa.subscription.module.interceptor.SubscriptionDebugLogInterceptor;
 import ca.uhn.fhir.jpa.util.ResourceProviderFactory;
 import ca.uhn.fhir.narrative.DefaultThymeleafNarrativeGenerator;
+import ca.uhn.fhir.rest.client.api.IGenericClient;
 import ca.uhn.fhir.rest.server.HardcodedServerAddressStrategy;
 import ca.uhn.fhir.rest.server.RestfulServer;
 import ca.uhn.fhir.rest.server.interceptor.CorsInterceptor;
@@ -50,6 +51,7 @@ import org.mitre.hapifhir.SubscriptionInterceptor;
 import org.mitre.hapifhir.model.SubscriptionTopic;
 import org.mitre.hapifhir.model.ResourceTrigger;
 import org.mitre.hapifhir.model.ResourceTrigger.MethodCriteria;
+import org.mitre.hapifhir.search.BearerAuthSearchClient;
 import org.mitre.hapifhir.TopicListInterceptor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpHeaders;
@@ -244,10 +246,11 @@ public class JpaRestfulServer extends RestfulServer {
     /*
      * Add Backport Subscription interceptor
      */
-    SubscriptionInterceptor subscriptionInterceptor = new SubscriptionInterceptor(HapiProperties.getServerAddress(), this.getFhirContext(), subscriptionTopics);
+    IGenericClient client = this.getFhirContext().newRestfulGenericClient(HapiProperties.getServerAddress());
+    BearerAuthSearchClient searchClient = new BearerAuthSearchClient(System.getenv("ADMIN_TOKEN"), client);
+    SubscriptionInterceptor subscriptionInterceptor = new SubscriptionInterceptor(HapiProperties.getServerAddress(), this.getFhirContext(), searchClient, subscriptionTopics);
     this.registerInterceptor(subscriptionInterceptor);
 
-    SearchParamMatcher ol;
     /*
      * Add Topic List interceptor
      */

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -45,7 +45,7 @@ import org.mitre.hapifhir.BackendAuthorizationInterceptor;
 import org.mitre.hapifhir.SMARTServerCapabilityStatementProvider;
 import org.mitre.hapifhir.ProcessMessageProvider;
 import org.mitre.hapifhir.SubscriptionInterceptor;
-import org.mitre.hapifhir.search.BearerAuthSearchClient;
+import org.mitre.hapifhir.client.BearerAuthServerClient;
 import org.mitre.hapifhir.TopicListInterceptor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpHeaders;
@@ -233,8 +233,8 @@ public class JpaRestfulServer extends RestfulServer {
      * Add Backport Subscription interceptor
      */
     IGenericClient client = this.getFhirContext().newRestfulGenericClient(HapiProperties.getServerAddress());
-    BearerAuthSearchClient searchClient = new BearerAuthSearchClient(System.getenv("ADMIN_TOKEN"), client);
-    SubscriptionInterceptor subscriptionInterceptor = new SubscriptionInterceptor(HapiProperties.getServerAddress(), this.getFhirContext(), searchClient, MedmorphSubscriptionTopics.getAllTopics());
+    BearerAuthServerClient serverClient = new BearerAuthServerClient(System.getenv("ADMIN_TOKEN"), client);
+    SubscriptionInterceptor subscriptionInterceptor = new SubscriptionInterceptor(HapiProperties.getServerAddress(), this.getFhirContext(), serverClient, MedmorphSubscriptionTopics.getAllTopics());
     this.registerInterceptor(subscriptionInterceptor);
 
     /*

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -18,9 +18,7 @@ import ca.uhn.fhir.jpa.provider.r4.JpaSystemProviderR4;
 import ca.uhn.fhir.jpa.provider.r5.JpaConformanceProviderR5;
 import ca.uhn.fhir.jpa.provider.r5.JpaSystemProviderR5;
 import ca.uhn.fhir.jpa.search.DatabaseBackedPagingProvider;
-import ca.uhn.fhir.jpa.searchparam.matcher.SearchParamMatcher;
 import ca.uhn.fhir.jpa.subscription.SubscriptionInterceptorLoader;
-import ca.uhn.fhir.jpa.subscription.dbmatcher.DaoSubscriptionMatcher;
 import ca.uhn.fhir.jpa.subscription.module.interceptor.SubscriptionDebugLogInterceptor;
 import ca.uhn.fhir.jpa.util.ResourceProviderFactory;
 import ca.uhn.fhir.narrative.DefaultThymeleafNarrativeGenerator;
@@ -35,7 +33,6 @@ import ca.uhn.fhir.rest.server.interceptor.ResponseValidatingInterceptor;
 import ca.uhn.fhir.validation.IValidatorModule;
 import ca.uhn.fhir.validation.ResultSeverityEnum;
 import java.util.HashSet;
-import java.util.List;
 import java.util.TreeSet;
 
 import org.hl7.fhir.r4.model.Bundle;
@@ -48,9 +45,6 @@ import org.mitre.hapifhir.BackendAuthorizationInterceptor;
 import org.mitre.hapifhir.SMARTServerCapabilityStatementProvider;
 import org.mitre.hapifhir.ProcessMessageProvider;
 import org.mitre.hapifhir.SubscriptionInterceptor;
-import org.mitre.hapifhir.model.SubscriptionTopic;
-import org.mitre.hapifhir.model.ResourceTrigger;
-import org.mitre.hapifhir.model.ResourceTrigger.MethodCriteria;
 import org.mitre.hapifhir.search.BearerAuthSearchClient;
 import org.mitre.hapifhir.TopicListInterceptor;
 import org.springframework.context.ApplicationContext;
@@ -59,7 +53,6 @@ import org.springframework.web.cors.CorsConfiguration;
 
 import javax.servlet.ServletException;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
@@ -237,24 +230,17 @@ public class JpaRestfulServer extends RestfulServer {
     this.registerInterceptor(authorizationInterceptor);
 
     /*
-     * Create Backport SubscriptionTopics
-     */
-    List<SubscriptionTopic> subscriptionTopics = new ArrayList<>();
-    ResourceTrigger resourceTrigger = new ResourceTrigger(ResourceType.Patient, Collections.singletonList(MethodCriteria.UPDATE));
-    subscriptionTopics.add(new SubscriptionTopic("subTop01", "demographic-change", "http://example.org/medmorph/subscriptiontopic/demographic-change", Collections.singletonList(resourceTrigger)));
-
-    /*
      * Add Backport Subscription interceptor
      */
     IGenericClient client = this.getFhirContext().newRestfulGenericClient(HapiProperties.getServerAddress());
     BearerAuthSearchClient searchClient = new BearerAuthSearchClient(System.getenv("ADMIN_TOKEN"), client);
-    SubscriptionInterceptor subscriptionInterceptor = new SubscriptionInterceptor(HapiProperties.getServerAddress(), this.getFhirContext(), searchClient, subscriptionTopics);
+    SubscriptionInterceptor subscriptionInterceptor = new SubscriptionInterceptor(HapiProperties.getServerAddress(), this.getFhirContext(), searchClient, MedmorphSubscriptionTopics.getAllTopics());
     this.registerInterceptor(subscriptionInterceptor);
 
     /*
      * Add Topic List interceptor
      */
-    TopicListInterceptor topicListInterceptor = new TopicListInterceptor(this.getFhirContext(), subscriptionTopics);
+    TopicListInterceptor topicListInterceptor = new TopicListInterceptor(this.getFhirContext(), MedmorphSubscriptionTopics.getAllTopics());
     this.registerInterceptor(topicListInterceptor);
 
     /*

--- a/src/main/java/ca/uhn/fhir/jpa/starter/MedmorphSubscriptionTopics.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/MedmorphSubscriptionTopics.java
@@ -1,0 +1,93 @@
+package ca.uhn.fhir.jpa.starter;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.hl7.fhir.r4.model.ResourceType;
+import org.mitre.hapifhir.model.ResourceTrigger;
+import org.mitre.hapifhir.model.SubscriptionTopic;
+import org.mitre.hapifhir.model.ResourceTrigger.MethodCriteria;
+
+public class MedmorphSubscriptionTopics {
+
+    /*
+     * Singleton instance so the topics are only created once 
+     */
+    private static MedmorphSubscriptionTopics singletonMedmorphSubscriptionTopics;
+
+    private List<SubscriptionTopic> subscriptionTopics;
+
+    private MedmorphSubscriptionTopics() {
+        ResourceTrigger newConditionResourceTrigger = new ResourceTrigger(ResourceType.Condition, Collections.singletonList(MethodCriteria.CREATE));
+        ResourceTrigger newMedicationRequestResourceTrigger = new ResourceTrigger(ResourceType.MedicationRequest, Collections.singletonList(MethodCriteria.CREATE));
+        ResourceTrigger newMedicationDispenseResourceTrigger = new ResourceTrigger(ResourceType.MedicationDispense, Collections.singletonList(MethodCriteria.CREATE));
+        ResourceTrigger newMedicationStatementResourceTrigger = new ResourceTrigger(ResourceType.MedicationStatement, Collections.singletonList(MethodCriteria.CREATE));
+        ResourceTrigger newMedicationAdministrationResourceTrigger = new ResourceTrigger(ResourceType.MedicationAdministration, Collections.singletonList(MethodCriteria.CREATE));
+        ResourceTrigger newServiveRequestResourceTrigger = new ResourceTrigger(ResourceType.ServiceRequest, Collections.singletonList(MethodCriteria.CREATE));
+        ResourceTrigger newProcedureResourceTrigger = new ResourceTrigger(ResourceType.Procedure, Collections.singletonList(MethodCriteria.CREATE));
+        ResourceTrigger newImmunizationResourceTrigger = new ResourceTrigger(ResourceType.Immunization, Collections.singletonList(MethodCriteria.CREATE));
+        ResourceTrigger newObervationResourceTrigger = new ResourceTrigger(ResourceType.Observation, Collections.singletonList(MethodCriteria.CREATE), "category=laboratory");
+        ResourceTrigger updateEncounterResourceTrigger = new ResourceTrigger(ResourceType.Encounter, Collections.singletonList(MethodCriteria.UPDATE));
+        ResourceTrigger updateConditionResourceTrigger = new ResourceTrigger(ResourceType.Condition, Collections.singletonList(MethodCriteria.UPDATE));
+        ResourceTrigger updateMedicationRequestResourceTrigger = new ResourceTrigger(ResourceType.MedicationRequest, Collections.singletonList(MethodCriteria.UPDATE));
+        ResourceTrigger updateMedicationDispenseResourceTrigger = new ResourceTrigger(ResourceType.MedicationDispense, Collections.singletonList(MethodCriteria.UPDATE));
+        ResourceTrigger updateMedicationStatementResourceTrigger = new ResourceTrigger(ResourceType.MedicationStatement, Collections.singletonList(MethodCriteria.UPDATE));
+        ResourceTrigger updateMedicationAdministrationResourceTrigger = new ResourceTrigger(ResourceType.MedicationAdministration, Collections.singletonList(MethodCriteria.UPDATE));
+        ResourceTrigger updateServiveRequestResourceTrigger = new ResourceTrigger(ResourceType.ServiceRequest, Collections.singletonList(MethodCriteria.UPDATE));
+        ResourceTrigger updateProcedureResourceTrigger = new ResourceTrigger(ResourceType.Procedure, Collections.singletonList(MethodCriteria.UPDATE));
+        ResourceTrigger updateImmunizationResourceTrigger = new ResourceTrigger(ResourceType.Immunization, Collections.singletonList(MethodCriteria.UPDATE));
+        ResourceTrigger updateObervationResourceTrigger = new ResourceTrigger(ResourceType.Observation, Collections.singletonList(MethodCriteria.UPDATE), "category=laboratory");
+        ResourceTrigger updatePatientResourceTrigger = new ResourceTrigger(ResourceType.Patient, Collections.singletonList(MethodCriteria.UPDATE));
+
+        List<ResourceTrigger> newDiagnosisTriggers = Collections.singletonList(newConditionResourceTrigger);
+        List<ResourceTrigger> newLabresultTriggers = Collections.singletonList(newObervationResourceTrigger);
+        List<ResourceTrigger> newOrderTriggers = Collections.singletonList(newServiveRequestResourceTrigger);
+        List<ResourceTrigger> newProcedureChangeTriggers = Collections.singletonList(newProcedureResourceTrigger);
+        List<ResourceTrigger> newImmunizationTriggers = Collections.singletonList(newImmunizationResourceTrigger);
+
+        List<ResourceTrigger> encounterChangeTriggers = Collections.singletonList(updateEncounterResourceTrigger);
+        List<ResourceTrigger> diagnosisChangeTriggers = Collections.singletonList(updateConditionResourceTrigger);
+        List<ResourceTrigger> labresultChangeTriggers = Collections.singletonList(updateObervationResourceTrigger);
+        List<ResourceTrigger> orderChangeTriggers = Collections.singletonList(updateServiveRequestResourceTrigger);
+        List<ResourceTrigger> procedureChangeTriggers = Collections.singletonList(updateProcedureResourceTrigger);
+        List<ResourceTrigger> immunizationChangeTriggers = Collections.singletonList(updateImmunizationResourceTrigger);
+        List<ResourceTrigger> demographicChangeTriggers = Collections.singletonList(updatePatientResourceTrigger);
+
+        List<ResourceTrigger> newMedicationTriggers = new ArrayList<>();
+        newMedicationTriggers.add(newMedicationRequestResourceTrigger);
+        newMedicationTriggers.add(newMedicationDispenseResourceTrigger);
+        newMedicationTriggers.add(newMedicationStatementResourceTrigger);
+        newMedicationTriggers.add(newMedicationAdministrationResourceTrigger);
+
+        List<ResourceTrigger> medicationChangeTriggers = new ArrayList<>();
+        medicationChangeTriggers.add(updateMedicationRequestResourceTrigger);
+        medicationChangeTriggers.add(updateMedicationDispenseResourceTrigger);
+        medicationChangeTriggers.add(updateMedicationStatementResourceTrigger);
+        medicationChangeTriggers.add(updateMedicationAdministrationResourceTrigger);
+
+        this.subscriptionTopics = new ArrayList<>();
+        this.subscriptionTopics.add(new SubscriptionTopic("encounter-change", "encounter-change", "http://example.org/medmorph/subscriptiontopic/encounter-change", encounterChangeTriggers));
+        this.subscriptionTopics.add(new SubscriptionTopic("diagnosis-change", "diagnosis-change", "http://example.org/medmorph/subscriptiontopic/diagnosis-change", diagnosisChangeTriggers));
+        this.subscriptionTopics.add(new SubscriptionTopic("new-diagnosis", "new-diagnosis", "http://example.org/medmorph/subscriptiontopic/new-diagnosis", newDiagnosisTriggers));
+        this.subscriptionTopics.add(new SubscriptionTopic("medication-change", "medication-change", "http://example.org/medmorph/subscriptiontopic/medication-change", medicationChangeTriggers));
+        this.subscriptionTopics.add(new SubscriptionTopic("new-medication", "new-medication", "http://example.org/medmorph/subscriptiontopic/new-medication", newMedicationTriggers));
+        this.subscriptionTopics.add(new SubscriptionTopic("labresult-change", "labresult-change", "http://example.org/medmorph/subscriptiontopic/labresult-change", labresultChangeTriggers));
+        this.subscriptionTopics.add(new SubscriptionTopic("new-labresult", "new-labresult", "http://example.org/medmorph/subscriptiontopic/new-labresult", newLabresultTriggers));
+        this.subscriptionTopics.add(new SubscriptionTopic("order-change", "order-change", "http://example.org/medmorph/subscriptiontopic/order-change", orderChangeTriggers));
+        this.subscriptionTopics.add(new SubscriptionTopic("new-order", "new-order", "http://example.org/medmorph/subscriptiontopic/new-order", newOrderTriggers));
+        this.subscriptionTopics.add(new SubscriptionTopic("procedure-change", "procedure-change", "http://example.org/medmorph/subscriptiontopic/procedure-change", procedureChangeTriggers));
+        this.subscriptionTopics.add(new SubscriptionTopic("new-procedure", "new-procedure", "http://example.org/medmorph/subscriptiontopic/new-procedure", newProcedureChangeTriggers));
+        this.subscriptionTopics.add(new SubscriptionTopic("immunization-change", "immunization-change", "http://example.org/medmorph/subscriptiontopic/immunization-change", immunizationChangeTriggers));
+        this.subscriptionTopics.add(new SubscriptionTopic("new-immunization", "new-immunization", "http://example.org/medmorph/subscriptiontopic/new-immunization", newImmunizationTriggers));
+        this.subscriptionTopics.add(new SubscriptionTopic("demographic-change", "demographic-change", "http://example.org/medmorph/subscriptiontopic/demographic-change", demographicChangeTriggers));
+    }
+    
+    public static List<SubscriptionTopic> getAllTopics() {
+        if (singletonMedmorphSubscriptionTopics == null) {
+            singletonMedmorphSubscriptionTopics = new MedmorphSubscriptionTopics();
+        }
+
+        return singletonMedmorphSubscriptionTopics.subscriptionTopics;
+    }
+}

--- a/src/main/resources/hapi.properties
+++ b/src/main/resources/hapi.properties
@@ -131,7 +131,7 @@ cors.allow_origin=*
 ##################################################
 
 # Enable REST Hook Subscription Channel
-subscription.resthook.enabled=true
+subscription.resthook.enabled=false
 
 # Enable Email Subscription Channel
 subscription.email.enabled=false


### PR DESCRIPTION
Utilize the R5 Subscription Backport Library for [r5-subscription-backport Pull/1](https://github.com/mcode/r5-subscription-backport/pull/1). 

I have currently only tested with demographic-change and new-labresult topics. When testing it would be good to try out a variety of combinations to truly stress test this.