### PR TITLE
Bump smart-backend-auth version in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
         <dependency>
         	<groupId>org.mitre.hapifhir</groupId>
         	<artifactId>smart-backend-auth</artifactId>
-        	<version>0.0.1</version>
+        	<version>0.0.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
This PR is needed to test the changes in `smart-backend-auth`