### PR TITLE
Docker IP fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ The easiest way to run this server is to use docker. If using docker-for-windows
 
 By default, docker on windows/mac will only allocate 2GB of local memory for docker containers. To change this, use the Docker GUI, accessed through the docker toolbar icon or app, and navigate to preferences. Open the resources/advanced tab and increase the memory from 2GB to at least 3GB. This should provide the fhir servers with enough memory to run properly.
 
+Since the Docker container maps ports, it must be aware of it's actual host IP and not just reference `localhost`. The `docker-compose` file expects `LOCAL_IP` environment variable to be set. The command below illustrates how to do this in one line on a MITRE Mac. Note this may change from device to device.
+
 Then, run the following commands:
 
 ```
 ./build-docker-image.bat
-docker-compose up
+LOCAL_IP=$(ifconfig utun2 | grep inet | grep -v inet6 | awk '{print $2}') docker-compose up
 ```
 
 This will create the `medmorph_fhir` image and spin up the `medmoprh_ehr` (on [http://localhost:8180/fhir](http://localhost:8180/fhir)), `knowledge_artifact` (on [http://localhost:8190/fhir](http://localhost:8190/fhir)), and `public_health_authority` (on [http://localhost:8181/fhir](http://localhost:8181/fhir)) containers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "8180:8080"
     environment:
-      - SERVER_ADDRESS=http://localhost:8180/fhir/
+      - SERVER_ADDRESS=http://${LOCAL_IP}:8180/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/ehr/protocol/openid-connect/
       - SERVER_TITLE=MedMorph EHR
       - ADMIN_TOKEN=admin
@@ -19,7 +19,7 @@ services:
     ports:
       - "8190:8080"
     environment:
-      - SERVER_ADDRESS=http://localhost:8190/fhir/
+      - SERVER_ADDRESS=http://${LOCAL_IP}:8190/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/knowledgeartifact/protocol/openid-connect/
       - SERVER_TITLE=Knowledge Artifact Repository
       - ADMIN_TOKEN=admin
@@ -30,7 +30,7 @@ services:
     ports:
       - "8181:8080"
     environment:
-      - SERVER_ADDRESS=http://localhost:8181/fhir/
+      - SERVER_ADDRESS=http://${LOCAL_IP}:8181/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/pha/protocol/openid-connect/
       - SERVER_TITLE=Public Health Authority
       - ADMIN_TOKEN=admin


### PR DESCRIPTION
The issue in Docker where PUT-ing a resource failed was due using `localhost` instead of an explicit IP. To get around this each container in the compose should use an IP instead of `localhost`. 

Updates the docker-compose file to use the `LOCAL_IP` env to set the container `BASE_URL`. Updated the README with instructions on how to run with IP.