### PR TITLE
Support client registration endpoint in smart config and metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Alternatively the server can be run without Docker. When testing changes publish
 ```sh
 export SERVER_ADDRESS=http://localhost:8080/medmorph/fhir
 export AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/ehr/protocol/openid-connect/
+export AUTH_SERVER_REGISTER_ADDRESS={'optional address for dynamic client registration'}
 export SERVER_TITLE=Medmorph
 export ADMIN_TOKEN=admin
 export REQUIRE_AUTH=true
@@ -69,7 +70,7 @@ server's FHIR endpoint will be available at
 
 ## Configuration
 
-Since this is a single repository and single docker image for multiple actors, each container should have its own properties. Right now the properties to configurate are `AUTH_SERVER_ADDRESS`, `SERVER_ADDRESS`, `SERVER_TITLE`, `ADMIN_TOKEN`, `REQUIRE_AUTH`. These are set through environment variables of the same names. Using compose will automatically create all necessary servers.
+Since this is a single repository and single docker image for multiple actors, each container should have its own properties. Right now the properties to configurate are `AUTH_SERVER_ADDRESS`, `AUTH_SERVER_REGISTER_ADDRESS`, `SERVER_ADDRESS`, `SERVER_TITLE`, `ADMIN_TOKEN`, `REQUIRE_AUTH`. These are set through environment variables of the same names. Using compose will automatically create all necessary servers.
 
 ## Authorization
 

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
         <dependency>
         	<groupId>org.mitre.hapifhir</groupId>
         	<artifactId>smart-backend-auth</artifactId>
-        	<version>0.0.2</version>
+        	<version>0.0.4</version>
         </dependency>
         <dependency>
         	<groupId>org.mitre.hapifhir</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -244,7 +244,7 @@
         <dependency>
         	<groupId>org.mitre.hapifhir</groupId>
         	<artifactId>smart-backend-auth</artifactId>
-        	<version>0.0.3</version>
+        	<version>0.0.2</version>
         </dependency>
         <dependency>
         	<groupId>org.mitre.hapifhir</groupId>

--- a/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/HapiProperties.java
@@ -24,6 +24,7 @@ import static org.apache.commons.lang3.StringUtils.*;
 public class HapiProperties {
   static final String ENABLE_INDEX_MISSING_FIELDS = "enable_index_missing_fields";
     static final String AUTH_SERVER_ADDRESS = "AUTH_SERVER_ADDRESS";
+    static final String AUTH_SERVER_REGISTER_ADDRESS = "AUTH_SERVER_REGISTER_ADDRESS";
     static final String AUTO_CREATE_PLACEHOLDER_REFERENCE_TARGETS = "auto_create_placeholder_reference_targets";
     static final String ENFORCE_REFERENTIAL_INTEGRITY_ON_WRITE = "enforce_referential_integrity_on_write";
     static final String ENFORCE_REFERENTIAL_INTEGRITY_ON_DELETE = "enforce_referential_integrity_on_delete";
@@ -260,6 +261,10 @@ public class HapiProperties {
 
     public static String getAuthServerCertsAddress() {
         return System.getenv(AUTH_SERVER_ADDRESS) + "certs";
+    }
+
+    public static String getAuthServerRegistrationAddress() {
+        return System.getenv(AUTH_SERVER_REGISTER_ADDRESS);
     }
 
     public static Integer getDefaultPageSize() {

--- a/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/JpaRestfulServer.java
@@ -148,7 +148,7 @@ public class JpaRestfulServer extends RestfulServer {
      */
     if (fhirVersion == FhirVersionEnum.R4) {
       SMARTServerCapabilityStatementProvider smartCSProvider =
-    			new SMARTServerCapabilityStatementProvider(HapiProperties.getAuthServerTokenAddress());
+    			new SMARTServerCapabilityStatementProvider(HapiProperties.getAuthServerTokenAddress(), HapiProperties.getAuthServerRegistrationAddress());
 
       final String serverTitle = title;
       

--- a/src/main/java/ca/uhn/fhir/jpa/starter/WellknownEndpointController.java
+++ b/src/main/java/ca/uhn/fhir/jpa/starter/WellknownEndpointController.java
@@ -18,7 +18,8 @@ public class WellknownEndpointController {
     @GetMapping(path = "/smart-configuration", produces = {"application/json"})
     public String getWellKnownJson(HttpServletRequest theRequest) {
     	String yourTokenUrl = HapiProperties.getAuthServerTokenAddress();
+        String yourRegisterUrl = HapiProperties.getAuthServerRegistrationAddress();
     	
-    	return WellknownEndpointHelper.getWellKnownJson(yourTokenUrl);
+    	return WellknownEndpointHelper.getWellKnownJson(yourTokenUrl, yourRegisterUrl);
     }
 }


### PR DESCRIPTION
Add config for registration endpoint. If found add to smart-configuration and metadata. 
See also https://github.com/mcode/smart-backend-auth/pull/5
Note: the tests are currently failing on github actions because they require the updated smart-backend-auth gradle library (from the PR linked above)