### PR TITLE
Create volumes to persist data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ target/
 # Data files
 synthea_data
 
+# Volume data - ignore sub directories but keep empty /data
+data/*
+!data/.gitkeep
+
 # Compiled class file
 *.class
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     restart: on-failure
     ports:
       - "8180:8080"
+    volumes:
+      - ./data/ehr:/var/lib/jetty/target
     environment:
       - SERVER_ADDRESS=http://${LOCAL_IP}:8180/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/ehr/protocol/openid-connect/
@@ -19,6 +21,8 @@ services:
     restart: on-failure
     ports:
       - "8190:8080"
+    volumes:
+      - ./data/kar:/var/lib/jetty/target
     environment:
       - SERVER_ADDRESS=http://${LOCAL_IP}:8190/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/knowledgeartifact/protocol/openid-connect/
@@ -31,6 +35,8 @@ services:
     restart: on-failure
     ports:
       - "8181:8080"
+    volumes:
+      - ./data/pha:/var/lib/jetty/target
     environment:
       - SERVER_ADDRESS=http://${LOCAL_IP}:8181/fhir/
       - AUTH_SERVER_ADDRESS=http://moonshot-dev.mitre.org:8090/auth/realms/pha/protocol/openid-connect/


### PR DESCRIPTION
Create a volume for each of the servers under the `/data` directory. This allows the database to be persisted between restarts (which occur every night on pathways.mitre.org). 
Note: compose will fail unless the parent `/data` directory exists. In git you can't commit an empty folder so the contents are ignored except for an empty `.gitkeep` file. This ensures anyone who clones the repo will have the `data` directory.